### PR TITLE
Fix build error when adding ppa:ondrej/php due to wrong locale

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4F4EA0AAE5267A6C && \
 apt-get install -y software-properties-common && \
 nginx=stable && \
 add-apt-repository ppa:nginx/$nginx && \
-add-apt-repository ppa:ondrej/php && \
+LANG=C.UTF-8 add-apt-repository ppa:ondrej/php && \
 apt-get update && \
 apt-get upgrade -y && \
 BUILD_PACKAGES="supervisor nginx php${IMAGE_PHP_VERSION}-fpm git php${IMAGE_PHP_VERSION}-mysql php-apcu php${IMAGE_PHP_VERSION}-curl php${IMAGE_PHP_VERSION}-gd php${IMAGE_PHP_VERSION}-intl php${IMAGE_PHP_VERSION}-mcrypt php${IMAGE_PHP_VERSION}-memcache php${IMAGE_PHP_VERSION}-sqlite php${IMAGE_PHP_VERSION}-tidy php${IMAGE_PHP_VERSION}-xmlrpc php${IMAGE_PHP_VERSION}-xsl php${IMAGE_PHP_VERSION}-pgsql php${IMAGE_PHP_VERSION}-mongo php${IMAGE_PHP_VERSION}-ldap pwgen php${IMAGE_PHP_VERSION}-cli curl" && \


### PR DESCRIPTION
Builds are broken because `add-apt-repository` is not currently working properly for non-UTF-8 locales. As stated here (at the bottom): https://hub.docker.com/r/byrnedo/nginx-php7-fpm/builds/bzje4ek6czubarxtk8qw3aq/

This should fix it. (it worked for me locally)